### PR TITLE
Fix the issue with both partition and non-partition column predicates

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPredicates.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPredicates.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.hudi;
+
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.predicate.TupleDomain;
+
+public class HudiPredicates
+{
+    private final TupleDomain<ColumnHandle> partitionColumnPredicates;
+    private final TupleDomain<ColumnHandle> regularColumnPredicates;
+
+    public HudiPredicates(TupleDomain<ColumnHandle> partitionColumnPredicates,
+                          TupleDomain<ColumnHandle> regularColumnPredicates)
+    {
+        this.partitionColumnPredicates = partitionColumnPredicates;
+        this.regularColumnPredicates = regularColumnPredicates;
+    }
+
+    public TupleDomain<ColumnHandle> getPartitionColumnPredicates()
+    {
+        return partitionColumnPredicates;
+    }
+
+    public TupleDomain<ColumnHandle> getRegularColumnPredicates()
+    {
+        return regularColumnPredicates;
+    }
+}

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiTableHandle.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiTableHandle.java
@@ -34,6 +34,7 @@ public class TestHudiTableHandle
                 "table",
                 "/tmp/hudi_trips",
                 HoodieTableType.valueOf(COPY_ON_WRITE.name()),
+                TupleDomain.none(),
                 TupleDomain.all());
 
         String json = codec.toJson(expectedHandle);
@@ -41,7 +42,8 @@ public class TestHudiTableHandle
 
         assertEquals(actualHandle.getSchemaName(), expectedHandle.getSchemaName());
         assertEquals(actualHandle.getTableName(), expectedHandle.getTableName());
-        assertEquals(actualHandle.getPredicate(), expectedHandle.getPredicate());
+        assertEquals(actualHandle.getPartitionPredicates(), expectedHandle.getPartitionPredicates());
+        assertEquals(actualHandle.getRegularPredicates(), expectedHandle.getRegularPredicates());
         assertEquals(actualHandle.getTableType(), expectedHandle.getTableType());
         assertEquals(actualHandle.getBasePath(), expectedHandle.getBasePath());
         assertEquals(actualHandle.getTableType(), expectedHandle.getTableType());


### PR DESCRIPTION
When running the query with both partition and non-partition column predicates, the query failed with `IllegalStateException`.  This is due to improper handling of predicates in `HudiMetadata::applyFilter`.
```
trino:default> select count(*) from localtest_hoodie_table_3 where partition = '2021-10-01' and round = 7;
```
```
java.lang.IllegalStateException: There is already a predicate.
	at com.google.common.base.Preconditions.checkState(Preconditions.java:502)
	at io.trino.plugin.hudi.HudiTableHandle.withPredicate(HudiTableHandle.java:146)
	at io.trino.plugin.hudi.HudiMetadata.applyFilter(HudiMetadata.java:141)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.applyFilter(ClassLoaderSafeConnectorMetadata.java:915)
	at io.trino.metadata.MetadataManager.applyFilter(MetadataManager.java:1837)
	at io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan.pushFilterIntoTableScan(PushPredicateIntoTableScan.java:227)
	at io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan.apply(PushPredicateIntoTableScan.java:102)
	at io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan.apply(PushPredicateIntoTableScan.java:68)
	at io.trino.sql.planner.iterative.IterativeOptimizer.transform(IterativeOptimizer.java:184)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreNode(IterativeOptimizer.java:159)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:131)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:217)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:126)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:217)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:126)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:217)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:126)
	at io.trino.sql.planner.iterative.IterativeOptimizer.optimize(IterativeOptimizer.java:109)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:230)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:215)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:210)
	at io.trino.execution.SqlQueryExecution.doPlanQuery(SqlQueryExecution.java:466)
	at io.trino.execution.SqlQueryExecution.planQuery(SqlQueryExecution.java:447)
	at io.trino.execution.SqlQueryExecution.start(SqlQueryExecution.java:388)
	at io.trino.execution.SqlQueryManager.createQuery(SqlQueryManager.java:243)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$startExecution$7(LocalDispatchQuery.java:143)
	at io.trino.$gen.Trino_365_322_g27b1b58_dirty____20211229_032558_2.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```