### PR TITLE
Improve performance of Hudi connector

### DIFF
--- a/plugin/trino-hudi/pom.xml
+++ b/plugin/trino-hudi/pom.xml
@@ -66,6 +66,10 @@
             <artifactId>log</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplit.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplit.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HivePartitionKey;
 import io.trino.spi.HostAddress;
+import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.predicate.TupleDomain;
 
@@ -40,6 +41,7 @@ public class HudiSplit
     private final List<HostAddress> addresses;
     private final TupleDomain<HiveColumnHandle> predicate;
     private final List<HivePartitionKey> partitionKeys;
+    private final SplitWeight splitWeight;
 
     @JsonCreator
     public HudiSplit(
@@ -49,7 +51,8 @@ public class HudiSplit
             @JsonProperty("fileSize") long fileSize,
             @JsonProperty("addresses") List<HostAddress> addresses,
             @JsonProperty("predicate") TupleDomain<HiveColumnHandle> predicate,
-            @JsonProperty("partitionKeys") List<HivePartitionKey> partitionKeys)
+            @JsonProperty("partitionKeys") List<HivePartitionKey> partitionKeys,
+            @JsonProperty("splitWeight") SplitWeight splitWeight)
     {
         checkArgument(start >= 0, "start must be positive");
         checkArgument(length >= 0, "length must be positive");
@@ -62,6 +65,7 @@ public class HudiSplit
         this.addresses = ImmutableList.copyOf(requireNonNull(addresses, "addresses is null"));
         this.predicate = requireNonNull(predicate, "predicate is null");
         this.partitionKeys = ImmutableList.copyOf(requireNonNull(partitionKeys, "partitionKeys is null"));
+        this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
     }
 
     @Override
@@ -86,6 +90,13 @@ public class HudiSplit
                 .put("length", length)
                 .put("fileSize", fileSize)
                 .build();
+    }
+
+    @JsonProperty
+    @Override
+    public SplitWeight getSplitWeight()
+    {
+        return splitWeight;
     }
 
     @JsonProperty

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/partition/HudiPartitionInfo.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/partition/HudiPartitionInfo.java
@@ -16,16 +16,24 @@ package io.trino.plugin.hudi.partition;
 
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HivePartitionKey;
+import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.predicate.TupleDomain;
 
 import java.util.List;
+import java.util.Optional;
 
 public abstract class HudiPartitionInfo
 {
     protected final Table table;
     protected final List<HiveColumnHandle> partitionColumnHandles;
     protected final TupleDomain<HiveColumnHandle> constraintSummary;
+
+    // Relative partition path
+    protected String relativePartitionPath;
+    // Hive partition name containing partition column key-value pairs
+    protected String hivePartitionName;
+    protected List<HivePartitionKey> hivePartitionKeys;
 
     public HudiPartitionInfo(
             Table table, List<HiveColumnHandle> partitionColumnHandles,
@@ -36,11 +44,10 @@ public abstract class HudiPartitionInfo
         this.constraintSummary = constraintSummary;
     }
 
-    // Relative partition path
-    protected String relativePartitionPath;
-    // Hive partition name containing partition column key-value pairs
-    protected String hivePartitionName;
-    protected List<HivePartitionKey> hivePartitionKeys;
+    public Table getTable()
+    {
+        return table;
+    }
 
     public abstract String getRelativePartitionPath();
 
@@ -49,4 +56,8 @@ public abstract class HudiPartitionInfo
     public abstract List<HivePartitionKey> getHivePartitionKeys();
 
     public abstract boolean doesMatchPredicates();
+
+    public abstract String getComparingKey();
+
+    public abstract void loadPartitionInfo(Optional<Partition> partition);
 }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/partition/HudiPartitionInfoLoader.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/partition/HudiPartitionInfoLoader.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.hudi.partition;
+
+import io.airlift.log.Logger;
+import io.trino.plugin.hive.metastore.Partition;
+import io.trino.plugin.hudi.query.HudiFileListing;
+import io.trino.spi.connector.ConnectorSession;
+import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.exception.HoodieIOException;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static io.trino.plugin.hudi.HudiSessionProperties.getMaxPartitionBatchSize;
+import static io.trino.plugin.hudi.HudiSessionProperties.getMinPartitionBatchSize;
+
+public class HudiPartitionInfoLoader
+        implements Runnable
+{
+    private static final Logger LOG = Logger.get(HudiPartitionInfoLoader.class);
+    private final HudiFileListing hudiFileListing;
+    private final int minPartitionBatchSize;
+    private final int maxPartitionBatchSize;
+    private final ArrayDeque<HudiPartitionInfo> partitionQueue;
+    private int currBatchSize;
+
+    public HudiPartitionInfoLoader(
+            ConnectorSession session,
+            HudiFileListing hudiFileListing,
+            ArrayDeque<HudiPartitionInfo> partitionQueue)
+    {
+        this.hudiFileListing = hudiFileListing;
+        this.partitionQueue = partitionQueue;
+        this.minPartitionBatchSize = getMinPartitionBatchSize(session);
+        this.maxPartitionBatchSize = getMaxPartitionBatchSize(session);
+        this.currBatchSize = -1;
+    }
+
+    @Override
+    public void run()
+    {
+        HoodieTimer timer = new HoodieTimer().startTimer();
+        List<HudiPartitionInfo> hudiPartitionInfoList = hudiFileListing.getPartitionsToScan().stream()
+                .sorted(Comparator.comparing(HudiPartitionInfo::getComparingKey)).collect(Collectors.toList());
+        boolean shouldUseHiveMetastore =
+                !hudiPartitionInfoList.isEmpty() && hudiPartitionInfoList.get(0) instanceof HudiPartitionHiveInfo;
+        Iterator<HudiPartitionInfo> iterator = hudiPartitionInfoList.iterator();
+        while (iterator.hasNext()) {
+            int batchSize = updateBatchSize();
+            List<HudiPartitionInfo> partitionInfoBatch = new ArrayList<>();
+            while (iterator.hasNext() && batchSize > 0) {
+                partitionInfoBatch.add(iterator.next());
+                batchSize--;
+            }
+
+            if (!partitionInfoBatch.isEmpty()) {
+                if (shouldUseHiveMetastore) {
+                    Map<String, Optional<Partition>> partitions =
+                            hudiFileListing.getPartitions(partitionInfoBatch.stream()
+                                    .map(HudiPartitionInfo::getHivePartitionName)
+                                    .collect(Collectors.toList()));
+                    partitionInfoBatch
+                            .forEach(partitionInfo -> {
+                                String hivePartitionName = partitionInfo.getHivePartitionName();
+                                if (!partitions.containsKey(hivePartitionName)) {
+                                    throw new HoodieIOException("Partition does not exist: " + hivePartitionName);
+                                }
+                                partitionInfo.loadPartitionInfo(partitions.get(hivePartitionName));
+                                synchronized (partitionQueue) {
+                                    partitionQueue.add(partitionInfo);
+                                }
+                            });
+                }
+                else {
+                    partitionInfoBatch.forEach(partitionInfo -> {
+                        partitionInfo.getHivePartitionKeys();
+                        synchronized (partitionQueue) {
+                            partitionQueue.add(partitionInfo);
+                        }
+                    });
+                }
+            }
+        }
+        LOG.debug(String.format("HudiPartitionInfoLoader finishes in %d ms", timer.endTimer()));
+    }
+
+    private int updateBatchSize()
+    {
+        if (currBatchSize <= 0) {
+            currBatchSize = minPartitionBatchSize;
+        }
+        else {
+            currBatchSize *= 2;
+            currBatchSize = Math.min(currBatchSize, maxPartitionBatchSize);
+        }
+        return currBatchSize;
+    }
+}

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/partition/HudiPartitionInternalInfo.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/partition/HudiPartitionInternalInfo.java
@@ -17,6 +17,7 @@ package io.trino.plugin.hudi.partition;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HivePartitionKey;
 import io.trino.plugin.hive.metastore.Column;
+import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hudi.HudiUtil;
 import io.trino.spi.predicate.TupleDomain;
@@ -25,6 +26,7 @@ import org.apache.hudi.hive.PartitionValueExtractor;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.isNull;
@@ -85,6 +87,19 @@ public class HudiPartitionInternalInfo
         return HudiUtil.doesPartitionMatchPredicates(
                 table.getSchemaTableName(), relativePartitionPath, partitionValues,
                 partitionColumnHandles, constraintSummary);
+    }
+
+    @Override
+    public String getComparingKey()
+    {
+        return relativePartitionPath;
+    }
+
+    @Override
+    public void loadPartitionInfo(Optional<Partition> partition)
+    {
+        throw new HoodieException(
+                "HudiPartitionInternalInfo::loadPartitionInfo() should not be called");
     }
 
     @Override

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiFileListingFactory.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiFileListingFactory.java
@@ -17,6 +17,7 @@ package io.trino.plugin.hudi.query;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.authentication.HiveIdentity;
 import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hudi.HudiTableHandle;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.engine.HoodieEngineContext;
@@ -32,18 +33,18 @@ public final class HudiFileListingFactory
     public static HudiFileListing get(
             HudiQueryMode queryMode, HoodieMetadataConfig metadataConfig,
             HoodieEngineContext engineContext, HudiTableHandle tableHandle,
-            HoodieTableMetaClient metaClient, HiveMetastore hiveMetastore,
+            HoodieTableMetaClient metaClient, HiveMetastore hiveMetastore, Table hiveTable,
             HiveIdentity hiveIdentity, List<HiveColumnHandle> partitionColumnHandles,
             boolean shouldSkipMetastoreForPartition)
     {
         switch (queryMode) {
             case SNAPSHOT:
                 return new HudiSnapshotFileListing(metadataConfig, engineContext, tableHandle,
-                        metaClient, hiveMetastore, hiveIdentity, partitionColumnHandles,
+                        metaClient, hiveMetastore, hiveTable, hiveIdentity, partitionColumnHandles,
                         shouldSkipMetastoreForPartition);
             case READ_OPTIMIZED:
                 return new HudiReadOptimizedFileListing(metadataConfig, engineContext, tableHandle,
-                        metaClient, hiveMetastore, hiveIdentity, partitionColumnHandles,
+                        metaClient, hiveMetastore, hiveTable, hiveIdentity, partitionColumnHandles,
                         shouldSkipMetastoreForPartition);
             default:
                 throw new HoodieException(

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiReadOptimizedFileListing.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiReadOptimizedFileListing.java
@@ -20,6 +20,7 @@ import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.authentication.HiveIdentity;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hudi.HudiSplitSource;
 import io.trino.plugin.hudi.HudiTableHandle;
 import io.trino.plugin.hudi.HudiUtil;
@@ -57,10 +58,10 @@ public class HudiReadOptimizedFileListing
     public HudiReadOptimizedFileListing(
             HoodieMetadataConfig metadataConfig, HoodieEngineContext engineContext,
             HudiTableHandle tableHandle, HoodieTableMetaClient metaClient,
-            HiveMetastore hiveMetastore, HiveIdentity hiveIdentity,
+            HiveMetastore hiveMetastore, Table hiveTable, HiveIdentity hiveIdentity,
             List<HiveColumnHandle> partitionColumnHandles, boolean shouldSkipMetastoreForPartition)
     {
-        super(metadataConfig, engineContext, tableHandle, metaClient, hiveMetastore,
+        super(metadataConfig, engineContext, tableHandle, metaClient, hiveMetastore, hiveTable,
                 hiveIdentity, partitionColumnHandles, shouldSkipMetastoreForPartition);
     }
 
@@ -71,9 +72,6 @@ public class HudiReadOptimizedFileListing
 
         initFileSystemViewAndPredicates();
 
-        hiveTable = hiveMetastore.getTable(
-                hiveIdentity, tableName.getSchemaName(), tableName.getTableName())
-                .orElseThrow(() -> new TableNotFoundException(tableName));
         partitionColumns = hiveTable.getPartitionColumns();
         List<HudiPartitionInfo> allPartitionInfoList = null;
 

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiSnapshotFileListing.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiSnapshotFileListing.java
@@ -17,6 +17,7 @@ package io.trino.plugin.hudi.query;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.authentication.HiveIdentity;
 import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hudi.HudiTableHandle;
 import io.trino.plugin.hudi.partition.HudiPartitionInfo;
 import org.apache.hadoop.fs.FileStatus;
@@ -32,10 +33,10 @@ public class HudiSnapshotFileListing
     public HudiSnapshotFileListing(
             HoodieMetadataConfig metadataConfig, HoodieEngineContext engineContext,
             HudiTableHandle tableHandle, HoodieTableMetaClient metaClient,
-            HiveMetastore hiveMetastore, HiveIdentity hiveIdentity,
+            HiveMetastore hiveMetastore, Table hiveTable, HiveIdentity hiveIdentity,
             List<HiveColumnHandle> partitionColumnHandles, boolean shouldSkipMetastoreForPartition)
     {
-        super(metadataConfig, engineContext, tableHandle, metaClient, hiveMetastore,
+        super(metadataConfig, engineContext, tableHandle, metaClient, hiveMetastore, hiveTable,
                 hiveIdentity, partitionColumnHandles, shouldSkipMetastoreForPartition);
     }
 

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/split/HudiSplitWeightProvider.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/split/HudiSplitWeightProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.hudi.split;
+
+import io.trino.spi.SplitWeight;
+
+public interface HudiSplitWeightProvider
+{
+    SplitWeight weightForSplitSizeInBytes(long splitSizeInBytes);
+
+    static HudiSplitWeightProvider uniformStandardWeightProvider()
+    {
+        return (splitSizeInBytes) -> SplitWeight.standard();
+    }
+}

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/split/SizeBasedSplitWeightProvider.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/split/SizeBasedSplitWeightProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.hudi.split;
+
+import io.airlift.units.DataSize;
+import io.trino.spi.SplitWeight;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class SizeBasedSplitWeightProvider
+        implements HudiSplitWeightProvider
+{
+    private final double minimumWeight;
+    private final double standardSplitSizeInBytes;
+
+    public SizeBasedSplitWeightProvider(double minimumWeight, DataSize standardSplitSize)
+    {
+        checkArgument(Double.isFinite(minimumWeight) && minimumWeight > 0 && minimumWeight <= 1,
+                "minimumWeight must be > 0 and <= 1, found: %s", minimumWeight);
+        this.minimumWeight = minimumWeight;
+        long standardSplitSizeInBytesLong = requireNonNull(
+                standardSplitSize, "standardSplitSize is null").toBytes();
+        checkArgument(standardSplitSizeInBytesLong > 0,
+                "standardSplitSize must be > 0, found: %s", standardSplitSize);
+        this.standardSplitSizeInBytes = (double) standardSplitSizeInBytesLong;
+    }
+
+    @Override
+    public SplitWeight weightForSplitSizeInBytes(long splitSizeInBytes)
+    {
+        double computedWeight = splitSizeInBytes / standardSplitSizeInBytes;
+        // Clamp the value be between the minimum weight and 1.0 (standard weight)
+        return SplitWeight.fromProportion(Math.min(Math.max(computedWeight, minimumWeight), 1.0));
+    }
+}

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSplit.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSplit.java
@@ -16,6 +16,7 @@ package io.trino.plugin.hudi;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.json.JsonCodec;
+import io.trino.spi.SplitWeight;
 import io.trino.spi.predicate.TupleDomain;
 import org.testng.annotations.Test;
 
@@ -35,7 +36,8 @@ public class TestHudiSplit
                 440747L,
                 ImmutableList.of(),
                 TupleDomain.all(),
-                ImmutableList.of());
+                ImmutableList.of(),
+                SplitWeight.fromProportion(0.1));
 
         String json = codec.toJson(expectedSplit);
         HudiSplit actualSplit = codec.fromJson(json);
@@ -46,6 +48,6 @@ public class TestHudiSplit
         assertEquals(actualSplit.getStart(), expectedSplit.getStart());
         assertEquals(actualSplit.getLength(), expectedSplit.getLength());
         assertEquals(actualSplit.getFileSize(), expectedSplit.getFileSize());
-        assertEquals(actualSplit.getAddresses(), expectedSplit.getAddresses());
+        assertEquals(actualSplit.getSplitWeight(), expectedSplit.getSplitWeight());
     }
 }


### PR DESCRIPTION
This PR brings the query performance on Hudi connector similar or better to that on Hive connector, under both modes of whether using Hive metastore to load partition information or not (previously query time on Hudi connector is 1.3x-2x of Hive connector).  Major changes to improve query performance:
- Removes redundant Hive metastore calls, especially `metastore.getTable()`.  This saves 400-500ms per query, which is significant for small queries.
- Adds split weight to HudiSplit based on the split size.  Before this change, the split weight is set to default 1.0, and that limits the number of splits scheduled to be running (queued + running) to 100.  This becomes the bottleneck for the query performance when the splits are small (e.g. a few MB).  The dynamic weight assignment allows much more splits to be scheduled to run, better using the compute and memory resources.
- When using Hive metastore to get partition information, instead of calling `metastore.getPartition()` for each individual partition, the new logic uses `metastore.getPartitionsByNames()` with a batch of partitions (10~100) to retrieve partition information much faster.  `metastore.getPartition()` and `metastore.getPartitionsByNames()` takes 80-150ms for each call.
- Adds a single-threaded `HudiPartitionInfoLoader` to load partition info solely.